### PR TITLE
Add Qualcomm CAPI volume example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # hobby
 Hobby repo
+
+This repository includes a basic Qualcomm CAPI module example in capi_volume.c.

--- a/capi_volume.c
+++ b/capi_volume.c
@@ -1,0 +1,97 @@
+#include "capi_v2.h"
+
+/* Example Qualcomm CAPI module for simple volume control */
+
+typedef struct {
+    capi_v2_t vtbl; /* callback table provided by the framework */
+    float gain;     /* gain factor applied in process */
+} capi_volume_t;
+
+/* Forward declarations of CAPI callbacks */
+static capi_v2_err_t capi_volume_init(capi_v2_t* _pif,
+                                      capi_v2_proplist_t* init_set_properties);
+static capi_v2_err_t capi_volume_process(capi_v2_t* _pif,
+                                         capi_v2_stream_data_t* input[],
+                                         capi_v2_stream_data_t* output[]);
+static capi_v2_err_t capi_volume_end(capi_v2_t* _pif);
+static capi_v2_err_t capi_volume_set_param(capi_v2_t* _pif,
+                                           uint32_t param_id,
+                                           const int8_t* payload,
+                                           uint32_t payload_size);
+static capi_v2_err_t capi_volume_get_param(capi_v2_t* _pif,
+                                           uint32_t param_id,
+                                           int8_t* payload,
+                                           uint32_t payload_size);
+static capi_v2_err_t capi_volume_set_properties(capi_v2_t* _pif,
+                                                capi_v2_proplist_t* props);
+static capi_v2_err_t capi_volume_get_properties(capi_v2_t* _pif,
+                                                capi_v2_proplist_t* props);
+
+/* Implementation of the callbacks */
+
+static capi_v2_err_t capi_volume_init(capi_v2_t* _pif, capi_v2_proplist_t* init_set_properties)
+{
+    capi_volume_t* me = (capi_volume_t*)_pif;
+    me->gain = 1.0f; /* default unity gain */
+    /* TODO: handle init_set_properties if required */
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_process(capi_v2_t* _pif,
+                                         capi_v2_stream_data_t* input[],
+                                         capi_v2_stream_data_t* output[])
+{
+    capi_volume_t* me = (capi_volume_t*)_pif;
+    int16_t* in  = (int16_t*)input[0]->buf_ptr;
+    int16_t* out = (int16_t*)output[0]->buf_ptr;
+
+    for (uint32_t i = 0; i < input[0]->bufs_num; ++i) {
+        out[i] = (int16_t)(me->gain * in[i]);
+    }
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_end(capi_v2_t* _pif)
+{
+    /* Clean up any resources if necessary */
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_set_param(capi_v2_t* _pif,
+                                           uint32_t param_id,
+                                           const int8_t* payload,
+                                           uint32_t payload_size)
+{
+    capi_volume_t* me = (capi_volume_t*)_pif;
+    if (param_id == SOME_GAIN_PARAM_ID && payload_size == sizeof(float)) {
+        me->gain = *(float*)payload;
+    }
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_get_param(capi_v2_t* _pif,
+                                           uint32_t param_id,
+                                           int8_t* payload,
+                                           uint32_t payload_size)
+{
+    capi_volume_t* me = (capi_volume_t*)_pif;
+    if (param_id == SOME_GAIN_PARAM_ID && payload_size == sizeof(float)) {
+        *(float*)payload = me->gain;
+    }
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_set_properties(capi_v2_t* _pif,
+                                                capi_v2_proplist_t* props)
+{
+    /* Handle property updates (e.g., port info, media format, etc.) */
+    return CAPI_V2_EOK;
+}
+
+static capi_v2_err_t capi_volume_get_properties(capi_v2_t* _pif,
+                                                capi_v2_proplist_t* props)
+{
+    /* Return properties such as algorithm version, port details, etc. */
+    return CAPI_V2_EOK;
+}
+


### PR DESCRIPTION
## Summary
- add a skeleton CAPI module `capi_volume.c`
- mention the new file in README

## Testing
- `pytest -q` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*